### PR TITLE
Remove version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,4 @@
 name: tcpie
-version: "4.0.2"
 summary: CLI tool to ping any TCP port
 description: |
   tcpie is a tool to measure latency and verify the reliabilty of a TCP connection.


### PR DESCRIPTION
the adopt-info tag should be getting the version so version: isn't necessary to specify, and seems to be overriding the version number incorrectly.