### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,13 @@ base: core18
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+  - build-on: s390x
+  - build-on: ppc64el
+
 apps:
   tcpie:
     command: tcpie


### PR DESCRIPTION
i386 no longer supported by node, so we shouldn't build tcpie for it